### PR TITLE
Fix(dc-testsuite.yml): Set referenced release version to 1.0.6 for docker image

### DIFF
--- a/dc-testsuite.yml
+++ b/dc-testsuite.yml
@@ -2,7 +2,7 @@
 name: dc-testsuite-kob
 services:
   kob-testsuite:
-    image: gematik1/kob-testsuite:1.0.5
+    image: gematik1/kob-testsuite:1.0.6
     container_name: kob-testsuite
     environment:
       - MAVEN_OPTS=-Dcucumber.filter.tags=${TESTSUITE_TESTS}


### PR DESCRIPTION
Die referenzierte Docker Image Version der KOB-Testsuite wurde beim Release/Tag 1.0.6 nicht aktualisiert.